### PR TITLE
검색 화면의 첫번째 구역인 SearchBarSectionView을 구현하였습니다.

### DIFF
--- a/IKEA/IKEA.xcodeproj/project.pbxproj
+++ b/IKEA/IKEA.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		7B082E1828E965C2002C0F45 /* IKEAUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B082E1728E965C2002C0F45 /* IKEAUITests.swift */; };
 		7B082E1A28E965C2002C0F45 /* IKEAUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B082E1928E965C2002C0F45 /* IKEAUITestsLaunchTests.swift */; };
 		7B082E2928E9B86B002C0F45 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B082E2828E9B86B002C0F45 /* SearchViewController.swift */; };
+		7B082E2F28EAD2DC002C0F45 /* SearchBarSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B082E2E28EAD2DC002C0F45 /* SearchBarSectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		7B082E1728E965C2002C0F45 /* IKEAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IKEAUITests.swift; sourceTree = "<group>"; };
 		7B082E1928E965C2002C0F45 /* IKEAUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IKEAUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		7B082E2828E9B86B002C0F45 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		7B082E2E28EAD2DC002C0F45 /* SearchBarSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 				7B082DF828E965C1002C0F45 /* SceneDelegate.swift */,
 				7B082DFA28E965C1002C0F45 /* ViewController.swift */,
 				7B082E2828E9B86B002C0F45 /* SearchViewController.swift */,
+				7B082E2D28EAD295002C0F45 /* SupportingView */,
 				7B082DFF28E965C1002C0F45 /* Assets.xcassets */,
 				7B082E0128E965C1002C0F45 /* LaunchScreen.storyboard */,
 				7B082E0428E965C1002C0F45 /* Info.plist */,
@@ -125,6 +128,14 @@
 				7B082E1928E965C2002C0F45 /* IKEAUITestsLaunchTests.swift */,
 			);
 			path = IKEAUITests;
+			sourceTree = "<group>";
+		};
+		7B082E2D28EAD295002C0F45 /* SupportingView */ = {
+			isa = PBXGroup;
+			children = (
+				7B082E2E28EAD2DC002C0F45 /* SearchBarSectionView.swift */,
+			);
+			path = SupportingView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -258,6 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B082DFB28E965C1002C0F45 /* ViewController.swift in Sources */,
+				7B082E2F28EAD2DC002C0F45 /* SearchBarSectionView.swift in Sources */,
 				7B082DF728E965C1002C0F45 /* AppDelegate.swift in Sources */,
 				7B082E2928E9B86B002C0F45 /* SearchViewController.swift in Sources */,
 				7B082DF928E965C1002C0F45 /* SceneDelegate.swift in Sources */,

--- a/IKEA/IKEA/SceneDelegate.swift
+++ b/IKEA/IKEA/SceneDelegate.swift
@@ -17,8 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windonScene = (scene as? UIWindowScene) else {return}
                window = UIWindow(windowScene: windonScene)
                let rootVC = SearchViewController()
-               let navVC = UINavigationController(rootViewController: rootVC)
-               self.window?.rootViewController = navVC
+               self.window?.rootViewController = rootVC
                window?.makeKeyAndVisible()
     }
 

--- a/IKEA/IKEA/SearchViewController.swift
+++ b/IKEA/IKEA/SearchViewController.swift
@@ -30,10 +30,9 @@ class SearchViewController: UIViewController {
         return $0
     }(UIStackView())
 
-    private let searchBarSectionView: UIView = {
-        $0.backgroundColor = .red
+    private let searchBarSectionView: SearchBarSectionView = {
         return $0
-    }(UIView())
+    }(SearchBarSectionView())
 
     private let recentProductSectionView: UIView = {
         $0.backgroundColor = .yellow
@@ -77,7 +76,6 @@ class SearchViewController: UIViewController {
 
     func setupAttributes() {
         view.backgroundColor = .systemBackground
-        setupNavigationBar()
     }
 
     func setupLayout() {
@@ -138,12 +136,6 @@ class SearchViewController: UIViewController {
             $0.heightAnchor.constraint(equalToConstant: 500).isActive = true
             self.stackView.addArrangedSubview($0)
         }
-    }
-
-    func setupNavigationBar() {
-        navigationItem.title = "검색"
-        navigationItem.largeTitleDisplayMode = .always
-        navigationController?.navigationBar.prefersLargeTitles = true
     }
 
 }

--- a/IKEA/IKEA/SearchViewController.swift
+++ b/IKEA/IKEA/SearchViewController.swift
@@ -74,16 +74,16 @@ class SearchViewController: UIViewController {
 
     // MARK: - func
 
-    func setupAttributes() {
+    private func setupAttributes() {
         view.backgroundColor = .systemBackground
     }
 
-    func setupLayout() {
+    private func setupLayout() {
         setupscrollView()
         setupstackView()
     }
 
-    func setupscrollView(){
+    private func setupscrollView(){
         view.addSubview(scrollView)
         let scrollViewConstraint = [
             scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
@@ -115,7 +115,7 @@ class SearchViewController: UIViewController {
         ])
     }
 
-    func setupstackView() {
+    private func setupstackView() {
         contentView.addSubview(stackView)
         let stackViewConstraint = [
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor),

--- a/IKEA/IKEA/SearchViewController.swift
+++ b/IKEA/IKEA/SearchViewController.swift
@@ -85,23 +85,15 @@ class SearchViewController: UIViewController {
 
     private func setupscrollView(){
         view.addSubview(scrollView)
-        let scrollViewConstraint = [
+        NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
-        ]
-        NSLayoutConstraint.activate(scrollViewConstraint)
+        ])
 
         scrollView.addSubview(contentView)
-        let contentViewConstraint = [
-            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
-            contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor)
-        ]
-        NSLayoutConstraint.activate(contentViewConstraint)
-
+        
         let contentViewCenterY = contentView.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor)
         contentViewCenterY.priority = .defaultLow
 
@@ -109,6 +101,10 @@ class SearchViewController: UIViewController {
         contentViewHeight.priority = .defaultLow
 
         NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
             contentView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
             contentViewCenterY,
             contentViewHeight
@@ -117,13 +113,12 @@ class SearchViewController: UIViewController {
 
     private func setupstackView() {
         contentView.addSubview(stackView)
-        let stackViewConstraint = [
+        NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-        ]
-        NSLayoutConstraint.activate(stackViewConstraint)
+        ])
         [
             searchBarSectionView,
             recentProductSectionView,

--- a/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
+++ b/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
@@ -8,28 +8,42 @@
 import UIKit
 
 class SearchBarSectionView: UIView {
-    
+
     // MARK: - Property
+
     private let titleLable: UILabel = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
         $0.text = "검색"
         $0.font = UIFont.boldSystemFont(ofSize: 22)
-        $0.translatesAutoresizingMaskIntoConstraints = false
         return $0
     }( UILabel())
 
-    let searchBarTextField: UITextField = {
+    private let searchBarbackground: UIView = {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.placeholder = "무엇을 찾고 있나요?"
-        $0.frame = CGRect(x: 0, y: 0, width: 0, height: 100)
-        $0.addLeftPadding()
         $0.layer.borderColor = UIColor.label.cgColor
         $0.layer.borderWidth = 1
         $0.layer.masksToBounds = true
-        $0.layer.cornerRadius = 10
+        $0.layer.cornerRadius = 25
         return $0
-    }(UITextField())
+    }(UIView())
+
+    private let searchBarIcon: UIImageView = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.image = UIImage(systemName: "magnifyingglass")
+        $0.tintColor = .systemGray
+        return $0
+    }(UIImageView())
+
+    private let searchBarPlaceholder: UILabel = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.font = UIFont.systemFont(ofSize: 14)
+        $0.text = "무엇을 찾고 있나요?"
+        $0.textColor = .systemGray2
+        return $0
+    }(UILabel())
 
     // MARK: - Init
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = .red
@@ -41,6 +55,7 @@ class SearchBarSectionView: UIView {
     }
 
     // MARK: - Method
+
     func setupLayout() {
         setupTitle()
         setupSearchBar()
@@ -48,39 +63,34 @@ class SearchBarSectionView: UIView {
 
     func setupTitle() {
         self.addSubview(titleLable)
-        let titleLableConstraint = [
+        NSLayoutConstraint.activate([
             titleLable.topAnchor.constraint(equalTo: self.topAnchor, constant: 30),
             titleLable.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 30)
-        ]
-        NSLayoutConstraint.activate(titleLableConstraint)
+        ])
     }
 
     func setupSearchBar() {
-        self.addSubview(searchBarTextField)
-        let searchBarTextFieldConstraint = [
-            searchBarTextField.topAnchor.constraint(equalTo: titleLable.bottomAnchor, constant: 30),
-            searchBarTextField.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 30),
-            searchBarTextField.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -30),
-            searchBarTextField.centerXAnchor.constraint(equalTo: self.centerXAnchor)
-        ]
-        NSLayoutConstraint.activate(searchBarTextFieldConstraint)
-        searchBarTextField.addleftimage(image: UIImage(systemName: "magnifyingglass")!)
-    }
-    
-}
+        self.addSubview(searchBarbackground)
+        NSLayoutConstraint.activate([
+            searchBarbackground.topAnchor.constraint(equalTo: titleLable.bottomAnchor, constant: 25),
+            searchBarbackground.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 30),
+            searchBarbackground.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -30),
+            searchBarbackground.heightAnchor.constraint(equalToConstant: 50)
+        ])
 
-extension UITextField {
-    func addLeftPadding() {
-        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 30, height: self.frame.height))
-        self.leftView = paddingView
-        self.leftViewMode = ViewMode.always
-    }
-    
-    func addleftimage(image:UIImage) {
-        let leftimage = UIImageView(frame: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-        leftimage.image = image
-        leftimage.tintColor = .systemGray
-        self.leftView = leftimage
-        self.leftViewMode = .always
+        searchBarbackground.addSubview(searchBarIcon)
+        NSLayoutConstraint.activate([
+            searchBarIcon.centerYAnchor.constraint(equalTo: searchBarbackground.centerYAnchor),
+            searchBarIcon.leadingAnchor.constraint(equalTo: searchBarbackground.leadingAnchor, constant: 20),
+            searchBarIcon.heightAnchor.constraint(equalToConstant: 20),
+            searchBarIcon.widthAnchor.constraint(equalToConstant: 20)
+        ])
+
+        searchBarbackground.addSubview(searchBarPlaceholder)
+        NSLayoutConstraint.activate([
+            searchBarPlaceholder.centerYAnchor.constraint(equalTo: searchBarbackground.centerYAnchor),
+            searchBarPlaceholder.leadingAnchor.constraint(equalTo: searchBarIcon.trailingAnchor, constant: 10)
+        ])
+
     }
 }

--- a/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
+++ b/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
@@ -56,12 +56,12 @@ class SearchBarSectionView: UIView {
 
     // MARK: - Method
 
-    func setupLayout() {
+    private func setupLayout() {
         setupTitle()
         setupSearchBar()
     }
 
-    func setupTitle() {
+    private func setupTitle() {
         self.addSubview(titleLable)
         NSLayoutConstraint.activate([
             titleLable.topAnchor.constraint(equalTo: self.topAnchor, constant: 30),
@@ -69,7 +69,7 @@ class SearchBarSectionView: UIView {
         ])
     }
 
-    func setupSearchBar() {
+    private func setupSearchBar() {
         self.addSubview(searchBarbackground)
         NSLayoutConstraint.activate([
             searchBarbackground.topAnchor.constraint(equalTo: titleLable.bottomAnchor, constant: 25),

--- a/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
+++ b/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
@@ -1,0 +1,27 @@
+//
+//  SearchBarSectionView.swift
+//  IKEA
+//
+//  Created by Yu ahyeon on 2022/10/03.
+//
+
+import UIKit
+
+class SearchBarSectionView: UIView {
+    
+    // MARK: - Property
+
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .red
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Method
+
+}

--- a/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
+++ b/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
@@ -16,25 +16,37 @@ class SearchBarSectionView: UIView {
         $0.translatesAutoresizingMaskIntoConstraints = false
         return $0
     }( UILabel())
-    
+
     let searchBarTextField: UITextField = {
         $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.placeholder = "무엇을 찾고 있나요?"
+        $0.frame = CGRect(x: 0, y: 0, width: 0, height: 100)
+        $0.addLeftPadding()
+        $0.layer.borderColor = UIColor.label.cgColor
+        $0.layer.borderWidth = 1
+        $0.layer.masksToBounds = true
+        $0.layer.cornerRadius = 10
         return $0
     }(UITextField())
-    
+
     // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = .red
         setupLayout()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Method
     func setupLayout() {
+        setupTitle()
+        setupSearchBar()
+    }
+
+    func setupTitle() {
         self.addSubview(titleLable)
         let titleLableConstraint = [
             titleLable.topAnchor.constraint(equalTo: self.topAnchor, constant: 30),
@@ -42,5 +54,33 @@ class SearchBarSectionView: UIView {
         ]
         NSLayoutConstraint.activate(titleLableConstraint)
     }
+
+    func setupSearchBar() {
+        self.addSubview(searchBarTextField)
+        let searchBarTextFieldConstraint = [
+            searchBarTextField.topAnchor.constraint(equalTo: titleLable.bottomAnchor, constant: 30),
+            searchBarTextField.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 30),
+            searchBarTextField.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -30),
+            searchBarTextField.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        ]
+        NSLayoutConstraint.activate(searchBarTextFieldConstraint)
+        searchBarTextField.addleftimage(image: UIImage(systemName: "magnifyingglass")!)
+    }
     
+}
+
+extension UITextField {
+    func addLeftPadding() {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 30, height: self.frame.height))
+        self.leftView = paddingView
+        self.leftViewMode = ViewMode.always
+    }
+    
+    func addleftimage(image:UIImage) {
+        let leftimage = UIImageView(frame: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+        leftimage.image = image
+        leftimage.tintColor = .systemGray
+        self.leftView = leftimage
+        self.leftViewMode = .always
+    }
 }

--- a/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
+++ b/IKEA/IKEA/SupportingView/SearchBarSectionView.swift
@@ -10,18 +10,37 @@ import UIKit
 class SearchBarSectionView: UIView {
     
     // MARK: - Property
-
+    private let titleLable: UILabel = {
+        $0.text = "검색"
+        $0.font = UIFont.boldSystemFont(ofSize: 22)
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        return $0
+    }( UILabel())
+    
+    let searchBarTextField: UITextField = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        return $0
+    }(UITextField())
     
     // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = .red
+        setupLayout()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - Method
-
+    func setupLayout() {
+        self.addSubview(titleLable)
+        let titleLableConstraint = [
+            titleLable.topAnchor.constraint(equalTo: self.topAnchor, constant: 30),
+            titleLable.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 30)
+        ]
+        NSLayoutConstraint.activate(titleLableConstraint)
+    }
+    
 }


### PR DESCRIPTION
## 👀 관련 이슈
#3 

## 👀 배경
### 🔎 검색화면의 첫번째 구역인  `타이틀`과 `검색창`이 있는 `SearchBarSectionView`을 구현했습니다.

<img src="https://user-images.githubusercontent.com/103012104/193599341-b68f89dc-86aa-4f2f-a088-789e13f52ea8.jpeg"  width="250" />



## 👀 작업 내용
1. 타이틀
-저번 PR에는 타이틀을 `Navigation Large Title`로 구현했지만,
`UILable`로 구현하는게 낫다고 판단되어 코드 수정했습니다.

2. 검색창
처음에는 검색창을 `UITextfield`로 구현하다가 
검색창 터치 시, 텍스트가 입력 되는게 아니라 페이지 전환이 이루어지기 때문에 
검색창을 `UITextfield`로 구현하는것이 부적합하다고 판단되어 `UIView`로 수정했습니다.

<img src="https://user-images.githubusercontent.com/103012104/193600491-228dde95-769a-455c-8412-4bfc629f1712.png"  width="250" />

3. 폴더 구조
SearchViewController를 구성하는 각 섹션의 UIView들은 
SupportingView라는 폴더를 만들어 그 안에 넣어 관리하려고 합니다.

<img src="https://user-images.githubusercontent.com/103012104/193601289-17ffd805-99a4-4f4c-ac6a-dbe7f2ed236c.png"  width="250" />

## 👀 PR Point
- 변수명이 적절한지
- AutoLayout의 사용이 적절한지
- 메소드 사용이 적절한지
- 개선하고 싶은 구현 방식이 있는지
위 사항을 위주로 말씀해주시면 감사하겠습니다!

## 👀 참고 사항
이렇게 구현하지 않았지만.... 
텍스트 필드에 이미지와 여백을 조절하기 위해 찾은 레퍼런스 공유드려요

https://fomaios.tistory.com/entry/iOSUI-%ED%85%8D%EC%8A%A4%ED%8A%B8%ED%95%84%EB%93%9C-%EC%95%88%EC%97%90-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EB%84%A3%EA%B8%B0-%EB%B0%8F-%EC%97%AC%EB%B0%B1%EC%A3%BC%EA%B8%B0UIImage-in-UITextField-and-Padding

https://developer-fury.tistory.com/46

https://velog.io/@yc1303/ios-textField-%EC%99%BC%EC%AA%BD-padding




